### PR TITLE
docs: update environment variable references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Before you begin, ensure you have the following installed:
       cp example.env .env
       ```
 
-    - Open the `.env` file and update the `USE_AUTH_TOKEN` variable with your newly generated Hugging Face token:
+    - Open the `.env` file and update the `HF_TOKEN` variable with your newly generated Hugging Face token:
 
       ```env
-      USE_AUTH_TOKEN=your_huggingface_token_here
+      HF_TOKEN=your_huggingface_token_here
       ```
     - Update the `LLM_API_URL` and `LLM_MODEL_NAME` variables to allow the backend to communicate with the LLM model you are using for summarisation of the transcripts.
         ```env

--- a/detailed_doc.md
+++ b/detailed_doc.md
@@ -99,7 +99,7 @@ Before downloading models, you must accept the licenses for the required PyAnnot
 2. **Configure the `.env` file**:
    ```env
    # Hugging Face authentication token
-   USE_AUTH_TOKEN=your_huggingface_token_here
+   HF_TOKEN=your_huggingface_token_here
    
    # LLM API configuration for summarization
    LLM_API_URL=your_llm_url


### PR DESCRIPTION
### Summary

Update documentation to reflect the correct environment variable name `HF_TOKEN` instead of the outdated `USE_AUTH_TOKEN` reference.

---

### Changes Made

- Updated README.md to reference `HF_TOKEN` instead of `USE_AUTH_TOKEN`
- Updated detailed_doc.md to reference `HF_TOKEN` instead of `USE_AUTH_TOKEN`
- Ensures documentation consistency with the current environment variable naming

---

### Context / Rationale

The environment variable name was changed to `HF_TOKEN` but the documentation still referenced the old `USE_AUTH_TOKEN` name. This update ensures developers following the setup instructions will use the correct variable name.

---

### Related Docs or References

Related to PR #92 which recreated the example.env file.

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards

🤖 Generated with [Claude Code](https://claude.ai/code)