### PR TITLE
feat: implement header logo with dark mode support and favicon

### DIFF
--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,20 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- MeetMemo icon - microphone with memo elements -->
+  <circle cx="16" cy="16" r="14" fill="#2998D5" stroke="#265289" stroke-width="2"/>
+  
+  <!-- Microphone body -->
+  <rect x="14" y="8" width="4" height="8" rx="2" fill="white"/>
+  
+  <!-- Microphone stand -->
+  <line x1="16" y1="16" x2="16" y2="20" stroke="white" stroke-width="1.5"/>
+  <line x1="12" y1="20" x2="20" y2="20" stroke="white" stroke-width="1.5"/>
+  
+  <!-- Sound waves -->
+  <path d="M10 12 Q 8 16 10 20" stroke="white" stroke-width="1" fill="none"/>
+  <path d="M22 12 Q 24 16 22 20" stroke="white" stroke-width="1" fill="none"/>
+  
+  <!-- Memo dots -->
+  <circle cx="20" cy="10" r="1" fill="white"/>
+  <circle cx="22" cy="12" r="1" fill="white"/>
+  <circle cx="21" cy="14" r="1" fill="white"/>
+</svg>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>MeetMemo</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#2998D5" />
     <link
       href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;700&display=swap"
       rel="stylesheet"

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,20 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- MeetMemo icon - microphone with memo elements -->
+  <circle cx="16" cy="16" r="14" fill="#2998D5" stroke="#265289" stroke-width="2"/>
+  
+  <!-- Microphone body -->
+  <rect x="14" y="8" width="4" height="8" rx="2" fill="white"/>
+  
+  <!-- Microphone stand -->
+  <line x1="16" y1="16" x2="16" y2="20" stroke="white" stroke-width="1.5"/>
+  <line x1="12" y1="20" x2="20" y2="20" stroke="white" stroke-width="1.5"/>
+  
+  <!-- Sound waves -->
+  <path d="M10 12 Q 8 16 10 20" stroke="white" stroke-width="1" fill="none"/>
+  <path d="M22 12 Q 24 16 22 20" stroke="white" stroke-width="1" fill="none"/>
+  
+  <!-- Memo dots -->
+  <circle cx="20" cy="10" r="1" fill="white"/>
+  <circle cx="22" cy="12" r="1" fill="white"/>
+  <circle cx="21" cy="14" r="1" fill="white"/>
+</svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "MeetMemo",
+  "name": "MeetMemo - AI Meeting Transcription",
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#2998D5",
+  "background_color": "#ffffff"
+}

--- a/frontend/src/MeetMemoIcon.js
+++ b/frontend/src/MeetMemoIcon.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const MeetMemoIcon = ({ size = 24, className = "" }) => {
+  return (
+    <svg 
+      width={size} 
+      height={size} 
+      viewBox="0 0 32 32" 
+      fill="none" 
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      {/* Background circle */}
+      <circle cx="16" cy="16" r="15" fill="currentColor" opacity="0.1"/>
+      
+      {/* Microphone body */}
+      <rect x="13" y="8" width="6" height="10" rx="3" fill="currentColor"/>
+      
+      {/* Microphone stand */}
+      <line x1="16" y1="18" x2="16" y2="22" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+      
+      {/* Microphone base */}
+      <line x1="12" y1="22" x2="20" y2="22" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+      
+      {/* Sound waves / memo lines */}
+      <path d="M8 12L10 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+      <path d="M8 14L11 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+      <path d="M8 16L10 16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+      
+      <path d="M22 12L24 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+      <path d="M21 14L24 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+      <path d="M22 16L24 16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+    </svg>
+  );
+};
+
+export default MeetMemoIcon;

--- a/frontend/src/MeetingTranscriptionApp.css
+++ b/frontend/src/MeetingTranscriptionApp.css
@@ -358,6 +358,21 @@ body {
   font-family: Barlow, sans-serif;
   font-weight: 700;
   margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.header-logo {
+  height: 2rem;
+  width: 2rem;
+  flex-shrink: 0;
+  transition: filter 0.3s ease;
+}
+
+/* Dark mode logo inversion */
+[data-theme="dark"] .header-logo {
+  filter: invert(1) hue-rotate(180deg);
 }
 
 .header-title,

--- a/frontend/src/MeetingTranscriptionApp.js
+++ b/frontend/src/MeetingTranscriptionApp.js
@@ -9,7 +9,6 @@ import {
   FileText,
   Hash,
   Send,
-  MessagesSquare,
   Trash2,
 } from "lucide-react";
 import "./MeetingTranscriptionApp.css";
@@ -17,6 +16,7 @@ import jsPDF from "jspdf";
 import { useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import MeetMemoIcon from "./MeetMemoIcon";
 
 const API_BASE_URL = `${window.location.protocol}//${window.location.hostname}:8000`;
 
@@ -716,7 +716,7 @@ const MeetingTranscriptionApp = () => {
         {/* Header */}
         <div className="header-card">
           <h1 className="header-title">
-            <MessagesSquare className="header-icon" /> MeetMemo
+            <img src="/logo.svg" alt="MeetMemo Logo" className="header-logo" /> MeetMemo
           </h1>
           <label className="theme-toggle" style={{ float: "right" }}>
             <input


### PR DESCRIPTION
## Summary
- Implemented custom SVG logo and favicon with MeetMemo microphone theme design
- Added header logo display that automatically adapts to light/dark themes using CSS filters
- Created PWA manifest and updated HTML metadata for enhanced mobile experience
- Replaced generic MessagesSquare icon with branded MeetMemo logo in application header

## Changes Made
- **New Files:**
  - `frontend/public/favicon.svg` - SVG favicon with microphone and memo dots design
  - `frontend/public/logo.svg` - Identical SVG for header logo (allows separate customization)
  - `frontend/public/manifest.json` - PWA manifest for mobile app experience
  - `frontend/src/MeetMemoIcon.js` - Reusable React icon component (for future use)

- **Updated Files:**
  - `frontend/public/index.html` - Added favicon, manifest, and theme color metadata
  - `frontend/src/MeetingTranscriptionApp.js` - Replaced MessagesSquare with logo image
  - `frontend/src/MeetingTranscriptionApp.css` - Added logo styling and dark mode inversion

## Technical Implementation
- **Dark Mode Support:** Logo automatically inverts colors using `filter: invert(1) hue-rotate(180deg)` in dark theme
- **Responsive Design:** Logo sized at 2rem × 2rem with proper flex alignment next to title
- **Smooth Transitions:** Added `transition: filter 0.3s ease` for seamless theme switching
- **PWA Ready:** Manifest enables "Add to Home Screen" functionality on mobile devices

## Test Plan
- [x] Verify logo displays correctly in light mode
- [x] Verify logo inverts properly in dark mode using theme toggle
- [x] Check favicon appears in browser tab
- [x] Confirm smooth color transition when switching themes
- [x] Test responsive behavior on different screen sizes
- [x] Validate PWA manifest loads correctly

## Visual Changes
The header now displays a branded MeetMemo logo (microphone with memo elements) instead of the generic MessagesSquare icon, providing better brand identity and visual consistency across the application.

🤖 Generated with [Claude Code](https://claude.ai/code)