### PR TITLE
feat: ensure PDF export and manual renames use proper speaker formatting

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -117,6 +117,25 @@ def format_result(diarized: list) -> list[dict]:
     return full_transcript
 
 
+def format_speaker_name(speaker_name: str) -> str:
+    """
+    Format speaker name from SPEAKER_XX format to 'Speaker X' format.
+    If the speaker name doesn't match SPEAKER_XX pattern, return as-is (manual rename takes priority).
+    """
+    if not speaker_name:
+        return "Speaker 1"
+    
+    # Check if it matches SPEAKER_XX pattern
+    import re
+    match = re.match(r'^SPEAKER_(\d+)$', speaker_name)
+    if match:
+        speaker_number = int(match.group(1)) + 1  # Convert 0-based to 1-based
+        return f"Speaker {speaker_number}"
+    
+    # If it doesn't match the pattern, it's likely a manual rename - return as-is
+    return speaker_name
+
+
 def get_unique_filename(directory: str, desired_filename: str, exclude_path: str = None) -> str:
     """
     Generate a unique filename by appending a counter if needed.
@@ -565,7 +584,8 @@ def generate_professional_pdf(summary_data: dict, transcript_data: list) -> Byte
         story.append(Spacer(1, 10))
         
         for i, entry in enumerate(transcript_data):
-            speaker = entry.get('speaker', 'Unknown Speaker')
+            raw_speaker = entry.get('speaker', 'Unknown Speaker')
+            speaker = format_speaker_name(raw_speaker)
             text = entry.get('text', '')
             start_time = entry.get('start', '0.00')
             end_time = entry.get('end', '0.00')

--- a/frontend/src/MeetingTranscriptionApp.js
+++ b/frontend/src/MeetingTranscriptionApp.js
@@ -51,6 +51,11 @@ const formatSpeakerName = (speakerName) => {
   return speakerName;
 };
 
+const getDisplaySpeakerName = (speakerName, speakerNameMap) => {
+  // Manual renames take priority over automatic formatting
+  return speakerNameMap[speakerName] ?? formatSpeakerName(speakerName);
+};
+
 const processTranscriptWithSpeakerIds = (transcriptData) => {
   const speakerMap = {};
   let speakerCounter = 1;
@@ -1256,7 +1261,7 @@ Check console for detailed breakdown.`);
     if (transcript.length === 0) return;
     let textContent = "Meeting Transcript\n\n";
     transcript.forEach((entry) => {
-      const speaker = speakerNameMap[entry.speaker] ?? formatSpeakerName(entry.speaker);
+      const speaker = getDisplaySpeakerName(entry.speaker, speakerNameMap);
       textContent += `${speaker}: ${entry.text}\n\n`;
     });
 
@@ -1727,7 +1732,7 @@ Check console for detailed breakdown.`);
                               <span
                                 className={`speaker-badge ${getSpeakerColor(entry.speakerId)}`}
                               >
-                                {speakerNameMap[entry.speaker] ?? formatSpeakerName(entry.speaker)}
+                                {getDisplaySpeakerName(entry.speaker, speakerNameMap)}
                               </span>
                               <button
                                 onClick={() => setEditingSpeaker(entry.speaker)}


### PR DESCRIPTION
- Add format_speaker_name function to backend for PDF generation
- Update PDF export to display "Speaker 1" instead of "SPEAKER_00"
- Manual speaker renames take priority over automatic formatting
- Add getDisplaySpeakerName helper function for consistent speaker display logic
- Maintain backward compatibility with existing SPEAKER_XX internal format

🤖 Generated with [Claude Code](https://claude.ai/code)
