### PR TITLE
fix: add LLM API key support for authenticated LLM servers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -331,7 +331,12 @@ def summarise_transcript(transcript: str, custom_prompt: str = None, system_prom
     }
 
     try:
-        resp = requests.post(url, headers={"Content-Type": "application/json"}, json=payload)
+        headers = {"Content-Type": "application/json"}
+        api_key = os.getenv("LLM_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        
+        resp = requests.post(url, headers=headers, json=payload)
         resp.raise_for_status()
         data = resp.json()
         summary = data["choices"][0]["message"]["content"].strip()

--- a/example.env
+++ b/example.env
@@ -7,3 +7,4 @@ HF_TOKEN=your_huggingface_token_here
 # LLM API Configuration
 LLM_API_URL=http://your_llm_host:port/vllm_qwen2.5
 LLM_MODEL_NAME=your_model_name
+LLM_API_KEY=your_llm_api_key_here


### PR DESCRIPTION
- Add LLM_API_KEY environment variable to example.env
- Update summarise_transcript function to include Bearer token in headers
- Maintain backward compatibility when no API key is provided

🤖 Generated with [Claude Code](https://claude.ai/code)
