### PR TITLE
fix: ensure edited transcripts are loaded in summary reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,4 @@ frontend/package.json
 # Code Assist Tools
 # -----------------------------
 .claude
-claude.md
+CLAUDE.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,6 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: meetmemo-backend
-    environment:
-      - HF_TOKEN=${HF_TOKEN:-CHANGEME}
-      - LLM_API_URL=${LLM_API_URL:-CHANGEME}
-      - LLM_MODEL_NAME=${LLM_MODEL_NAME:-CHANGEME}
-      - PYTHONUNBUFFERED=1
     volumes:
       - audiofiles:/app/audiofiles
       - logs:/app/logs
@@ -17,13 +12,13 @@ services:
       - whisper_cache:/root/.cache/whisper
     ports:
       - "8000:8000"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+    runtime: nvidia
+    environment:
+      - HF_TOKEN=${HF_TOKEN:-CHANGEME}
+      - LLM_API_URL=${LLM_API_URL:-CHANGEME}
+      - LLM_MODEL_NAME=${LLM_MODEL_NAME:-CHANGEME}
+      - PYTHONUNBUFFERED=1
+      - NVIDIA_VISIBLE_DEVICES=2
     networks:
       - meetmemo-network
 

--- a/frontend/src/MeetingTranscriptionApp.js
+++ b/frontend/src/MeetingTranscriptionApp.js
@@ -466,56 +466,6 @@ const MeetingTranscriptionApp = () => {
     debouncedSaveTranscript(updatedTranscript);
   };
 
-  // Debounced function to save transcript changes
-  const debounceTimeoutRef = useRef(null);
-  
-  const saveTranscriptToServer = useCallback(async (updatedTranscript) => {
-    if (!selectedMeetingId) return;
-    
-    setIsSavingTranscript(true);
-    setTranscriptSaveStatus('saving');
-    
-    try {
-      const response = await fetch(`${API_BASE_URL}/jobs/${selectedMeetingId}/transcript`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ transcript: updatedTranscript })
-      });
-      
-      if (!response.ok) {
-        throw new Error('Failed to save transcript');
-      }
-      
-      setTranscriptSaveStatus('saved');
-      setTimeout(() => setTranscriptSaveStatus(null), 2000);
-    } catch (error) {
-      console.error('Error saving transcript:', error);
-      setTranscriptSaveStatus('error');
-      setTimeout(() => setTranscriptSaveStatus(null), 3000);
-    } finally {
-      setIsSavingTranscript(false);
-    }
-  }, [selectedMeetingId]);
-
-  const debouncedSaveTranscript = useCallback((updatedTranscript) => {
-    if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current);
-    }
-    
-    debounceTimeoutRef.current = setTimeout(() => {
-      saveTranscriptToServer(updatedTranscript);
-    }, 1000); // 1 second delay
-  }, [saveTranscriptToServer]);
-
-  const handleTranscriptTextChange = (entryId, newText) => {
-    const updatedTranscript = transcript.map(entry => 
-      entry.id === entryId ? { ...entry, text: newText } : entry
-    );
-    
-    setTranscript(updatedTranscript);
-    debouncedSaveTranscript(updatedTranscript);
-  };
-
   const toggleTextEditing = (entryId) => {
     setEditingTranscriptEntry(
       editingTranscriptEntry === entryId ? null : entryId
@@ -1000,7 +950,7 @@ const MeetingTranscriptionApp = () => {
     
     if (window.confirm("Are you sure you want to reset all transcript edits? This will revert all text changes back to the original.")) {
       setTranscript([...originalTranscript]); // Reset to original transcript
-      setEditingText(null); // Clear any active editing
+      setEditingTranscriptEntry(null); // Clear any active editing
       console.log("Reset transcript to original version");
     }
   };
@@ -1018,7 +968,7 @@ const MeetingTranscriptionApp = () => {
           setOriginalTranscript([]); // Clear original transcript too
           setSummary(null);
           setSelectedMeetingId(null);
-          setEditingText(null); // Clear any active text editing
+          setEditingTranscriptEntry(null); // Clear any active text editing
         }
       })
       .catch((err) => console.error("Delete failed:", err));


### PR DESCRIPTION
- Update get_file_transcript() to prioritize edited transcripts over original
- Check transcripts/edited/{filename}.json first, fall back to original
- Add is_edited flag to transcript response for debugging
- Remove duplicate code blocks in frontend MeetingTranscriptionApp.js
- Fix undefined variable references (setEditingText -> setEditingTranscriptEntry)
- Update docker-compose.yml to use nvidia runtime for better GPU support

This resolves the issue where summary generation and PDF exports were using original transcripts instead of user-edited versions.

🤖 Generated with [Claude Code](https://claude.ai/code)
