### PR TITLE
fix: restore github-pages environment requirement for deploy action

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -55,6 +55,9 @@ jobs:
         path: ./frontend/build
         
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
The actions/deploy-pages@v4 action requires an environment to be specified. The issue was repository environment protection rules, not the workflow config. Repository settings need to be updated to allow main branch deployments.

🤖 Generated with [Claude Code](https://claude.ai/code)
