### PR TITLE
fix: set correct homepage path for GitHub Pages deployment

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "meet-memo",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/",
+  "homepage": "/MeetMemo/",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
Updates homepage from "/" to "/MeetMemo/" to fix asset loading issues when deployed to GitHub Pages subdirectory.

🤖 Generated with [Claude Code](https://claude.ai/code)
