### PR TITLE
feat: add demo mode to skip backend health check for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -38,6 +38,8 @@ jobs:
       run: |
         cd frontend
         npm run build
+      env:
+        VITE_DEMO_MODE: 'true'
 
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/example.env
+++ b/example.env
@@ -33,3 +33,7 @@ TIMEZONE_OFFSET=+8
 # Control which NVIDIA GPUs are visible to the container
 # Options: 'all', '0', '0,1', etc.
 NVIDIA_VISIBLE_DEVICES=all
+
+# Demo Mode (optional)
+# Set to 'true' to skip backend health check (for static deployments like GitHub Pages)
+VITE_DEMO_MODE=false

--- a/frontend/src/hooks/useBackendHealth.js
+++ b/frontend/src/hooks/useBackendHealth.js
@@ -1,15 +1,24 @@
 import { useState, useEffect } from 'react';
 import * as api from '../services/api';
 
+// Demo mode: skip backend health check (for GitHub Pages deployment)
+const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
+
 /**
  * Custom hook for backend health checking and connection management
  * Retries connection up to 30 times (30 seconds) before showing error
+ * In demo mode, immediately returns ready state without checking backend
  */
 export default function useBackendHealth() {
-  const [backendReady, setBackendReady] = useState(false);
+  const [backendReady, setBackendReady] = useState(DEMO_MODE);
   const [backendError, setBackendError] = useState(null);
 
   useEffect(() => {
+    // Skip health check in demo mode
+    if (DEMO_MODE) {
+      return;
+    }
+
     const checkBackendHealth = async () => {
       let retryCount = 0;
       const maxRetries = 30; // 30 retries = 30 seconds


### PR DESCRIPTION
- Add VITE_DEMO_MODE env variable to bypass backend health check
- Enable demo mode in GitHub Pages workflow build step
- Document the option in example.env

This allows the frontend to load on GitHub Pages without waiting for a backend that doesn't exist.
