### PR TITLE
fix: cleanup scheduler and UI improvements

### DIFF
--- a/frontend/src/components/Upload/RecentJobsList.jsx
+++ b/frontend/src/components/Upload/RecentJobsList.jsx
@@ -1,5 +1,13 @@
-import { Card, Badge, Button, Alert } from '@govtechsg/sgds-react';
+import { Card, Badge, Button } from '@govtechsg/sgds-react';
 import { Clock, AlertCircle, Trash2 } from 'lucide-react';
+
+const DATE_TIME_FORMAT_OPTIONS = {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+};
 
 export default function RecentJobsList({
   recentJobs,
@@ -35,7 +43,9 @@ export default function RecentJobsList({
                 <div className="flex-grow-1">
                   <div className="fw-medium">{job.filename || 'Untitled Recording'}</div>
                   <small className="text-muted">
-                    {job.created_at ? new Date(job.created_at).toLocaleString() : 'Date unknown'}
+                    {job.created_at
+                      ? new Date(job.created_at).toLocaleString('en-GB', DATE_TIME_FORMAT_OPTIONS)
+                      : 'Date unknown'}
                   </small>
                 </div>
                 <div className="d-flex gap-2 align-items-center">

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,13 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// Base path for GitHub Pages deployment
-const GITHUB_PAGES_BASE = '/MeetMemo/';
-
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig(() => ({
   plugins: [react()],
-  base: command === 'build' ? GITHUB_PAGES_BASE : '/',
+  // Use /MeetMemo/ base path only for GitHub Pages (when VITE_DEMO_MODE is set)
+  base: process.env.VITE_DEMO_MODE === 'true' ? '/MeetMemo/' : '/',
   server: {
     host: '0.0.0.0',
     port: 3000,


### PR DESCRIPTION
- Fix cleanup scheduler not working due to separate event loop
  - Changed from Thread with asyncio.run() to asyncio.create_task()
  - Cleanup now runs in the same event loop as the database pool
- Change date format in Recent Meetings to dd/mm/yyyy (en-GB locale)
- Use VITE_DEMO_MODE env var for base path in vite config
  - Docker builds now use '/' base path
  - Only GitHub Pages builds use '/MeetMemo/' base path
