### PR TITLE
fix: remove padding from recent meetings card body

### DIFF
--- a/frontend/src/components/Upload/RecentJobsList.jsx
+++ b/frontend/src/components/Upload/RecentJobsList.jsx
@@ -23,7 +23,7 @@ export default function RecentJobsList({
           Recent Meetings
         </h5>
       </Card.Header>
-      <Card.Body>
+      <Card.Body className="p-0">
         {loadingJobs ? (
           <div className="text-center text-muted py-4">
             <div className="spinner-border spinner-border-sm me-2" role="status">


### PR DESCRIPTION
Remove padding from the card-body in the Recent Meetings section to allow list items to extend to the edges of the card for a cleaner, more modern appearance.
