### PR TITLE
fix: add tip to Edit Speaker modal about adding new speakers

### DIFF
--- a/frontend/src/components/Modals/EditSpeakersModal.jsx
+++ b/frontend/src/components/Modals/EditSpeakersModal.jsx
@@ -26,6 +26,9 @@ export default function EditSpeakersModal({
             Replace speaker labels with actual names. AI suggestions are automatically applied when
             available.
           </p>
+          <p className="text-muted small mb-2">
+            <strong>Tip:</strong> To add a new speaker, use the ✏️ button on any transcript segment.
+          </p>
           {identifyingSpeakers && (
             <div className="text-muted small">
               <span


### PR DESCRIPTION
Users were confused trying to add new speakers in the Edit Speaker modal. Added a helpful tip directing them to use the edit button on transcript segments.
