### PR TITLE
feat: add workflow for GHCR publishing

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,79 @@
+name: Publish to GHCR
+
+on:
+  # Triggers minor version ( vX.Y.Z-ShortHash )
+  push:
+    branches:
+      - main
+  # Triggers major version ( vX.Y.Z )
+  release:
+    types: [created]
+
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - name: meetmemo-frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+          - name: meetmemo-backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+
+          # Use the input tag or default to 'latest'
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+
+          # Also create a tag with the commit SHA
+          echo "SHA_TAG=${TAG}-${SHORT_SHA}" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ env.SHA_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Log out of GitHub Container Registry
+        if: always()
+        run: docker logout ghcr.io


### PR DESCRIPTION
Add workflow to publish Docker containers to GitHub Container Registry. Supports frontend and backend containers with flexible tagging options.

Closes #144
