### PR TITLE
fix: improve upload UI — selected file text, badge label, delete confirmation modal

### DIFF
--- a/frontend/src/components/Upload/FileUploadCard.jsx
+++ b/frontend/src/components/Upload/FileUploadCard.jsx
@@ -70,11 +70,6 @@ export default function FileUploadCard({
             <span>Uploading...</span>
           </div>
         )}
-        {selectedFile && !uploading && (
-          <div className="mt-3">
-            <small className="text-success">Selected: {selectedFile.name}</small>
-          </div>
-        )}
       </Card.Body>
     </Card>
   );

--- a/frontend/src/components/Upload/RecentJobsList.jsx
+++ b/frontend/src/components/Upload/RecentJobsList.jsx
@@ -1,4 +1,5 @@
-import { Card, Badge, Button } from '@govtechsg/sgds-react';
+import { useState } from 'react';
+import { Card, Badge, Button, Modal } from '@govtechsg/sgds-react';
 import { Clock, AlertCircle, Trash2 } from 'lucide-react';
 
 const DATE_TIME_FORMAT_OPTIONS = {
@@ -15,7 +16,20 @@ export default function RecentJobsList({
   handleLoadJob,
   handleDeleteJob,
 }) {
+  const [pendingDeleteUuid, setPendingDeleteUuid] = useState(null);
+
+  const onDeleteClick = (uuid, e) => {
+    e.stopPropagation();
+    setPendingDeleteUuid(uuid);
+  };
+
+  const onConfirmDelete = () => {
+    handleDeleteJob(pendingDeleteUuid);
+    setPendingDeleteUuid(null);
+  };
+
   return (
+    <>
     <Card className="mt-4">
       <Card.Header>
         <h5 className="mb-0">
@@ -55,20 +69,20 @@ export default function RecentJobsList({
                         ? 'success'
                         : job.status_code === 202 || job.status_code === '202'
                           ? 'warning'
-                          : 'secondary'
+                          : 'danger'
                     }
                   >
                     {job.status_code === 200 || job.status_code === '200'
                       ? 'Complete'
                       : job.status_code === 202 || job.status_code === '202'
                         ? 'Processing'
-                        : 'Unknown'}
+                        : 'Failed'}
                   </Badge>
                   <Button
                     variant="link"
                     size="sm"
                     className="p-0 text-danger"
-                    onClick={(e) => handleDeleteJob(job.uuid, e)}
+                    onClick={(e) => onDeleteClick(job.uuid, e)}
                     title="Delete this meeting"
                   >
                     <Trash2 size={16} />
@@ -90,5 +104,23 @@ export default function RecentJobsList({
         </div>
       </Card.Body>
     </Card>
+
+      <Modal show={!!pendingDeleteUuid} onHide={() => setPendingDeleteUuid(null)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete Meeting</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Are you sure you want to delete this meeting? This action cannot be undone.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setPendingDeleteUuid(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirmDelete}>
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/components/Upload/RecentJobsList.jsx
+++ b/frontend/src/components/Upload/RecentJobsList.jsx
@@ -23,87 +23,87 @@ export default function RecentJobsList({
     setPendingDeleteUuid(uuid);
   };
 
-  const onConfirmDelete = () => {
-    handleDeleteJob(pendingDeleteUuid);
+  const onConfirmDelete = async () => {
+    await handleDeleteJob(pendingDeleteUuid);
     setPendingDeleteUuid(null);
   };
 
   return (
     <>
-    <Card className="mt-4">
-      <Card.Header>
-        <h5 className="mb-0">
-          <Clock size={20} className="me-2" />
-          Recent Meetings
-        </h5>
-      </Card.Header>
-      <Card.Body className="p-0">
-        {loadingJobs ? (
-          <div className="text-center text-muted py-4">
-            <div className="spinner-border spinner-border-sm me-2" role="status">
-              <span className="visually-hidden">Loading...</span>
-            </div>
-            <span>Loading recent meetings...</span>
-          </div>
-        ) : recentJobs.length > 0 ? (
-          <div className="list-group list-group-flush">
-            {recentJobs.map((job) => (
-              <div
-                key={job.uuid}
-                className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-                style={{ cursor: 'pointer' }}
-                onClick={() => handleLoadJob(job)}
-              >
-                <div className="flex-grow-1">
-                  <div className="fw-medium">{job.filename || 'Untitled Recording'}</div>
-                  <small className="text-muted">
-                    {job.created_at
-                      ? new Date(job.created_at).toLocaleString('en-GB', DATE_TIME_FORMAT_OPTIONS)
-                      : 'Date unknown'}
-                  </small>
-                </div>
-                <div className="d-flex gap-2 align-items-center">
-                  <Badge
-                    bg={
-                      job.status_code === 200 || job.status_code === '200'
-                        ? 'success'
-                        : job.status_code === 202 || job.status_code === '202'
-                          ? 'warning'
-                          : 'danger'
-                    }
-                  >
-                    {job.status_code === 200 || job.status_code === '200'
-                      ? 'Complete'
-                      : job.status_code === 202 || job.status_code === '202'
-                        ? 'Processing'
-                        : 'Failed'}
-                  </Badge>
-                  <Button
-                    variant="link"
-                    size="sm"
-                    className="p-0 text-danger"
-                    onClick={(e) => onDeleteClick(job.uuid, e)}
-                    title="Delete this meeting"
-                  >
-                    <Trash2 size={16} />
-                  </Button>
-                </div>
+      <Card className="mt-4">
+        <Card.Header>
+          <h5 className="mb-0">
+            <Clock size={20} className="me-2" />
+            Recent Meetings
+          </h5>
+        </Card.Header>
+        <Card.Body className="p-0">
+          {loadingJobs ? (
+            <div className="text-center text-muted py-4">
+              <div className="spinner-border spinner-border-sm me-2" role="status">
+                <span className="visually-hidden">Loading...</span>
               </div>
-            ))}
+              <span>Loading recent meetings...</span>
+            </div>
+          ) : recentJobs.length > 0 ? (
+            <div className="list-group list-group-flush">
+              {recentJobs.map((job) => (
+                <div
+                  key={job.uuid}
+                  className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => handleLoadJob(job)}
+                >
+                  <div className="flex-grow-1">
+                    <div className="fw-medium">{job.filename || 'Untitled Recording'}</div>
+                    <small className="text-muted">
+                      {job.created_at
+                        ? new Date(job.created_at).toLocaleString('en-GB', DATE_TIME_FORMAT_OPTIONS)
+                        : 'Date unknown'}
+                    </small>
+                  </div>
+                  <div className="d-flex gap-2 align-items-center">
+                    <Badge
+                      bg={
+                        job.status_code === 200 || job.status_code === '200'
+                          ? 'success'
+                          : job.status_code === 202 || job.status_code === '202'
+                            ? 'warning'
+                            : 'danger'
+                      }
+                    >
+                      {job.status_code === 200 || job.status_code === '200'
+                        ? 'Complete'
+                        : job.status_code === 202 || job.status_code === '202'
+                          ? 'Processing'
+                          : 'Failed'}
+                    </Badge>
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="p-0 text-danger"
+                      onClick={(e) => onDeleteClick(job.uuid, e)}
+                      title="Delete this meeting"
+                    >
+                      <Trash2 size={16} />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center text-muted py-4">
+              <p className="mb-0">
+                No recent meetings. Upload or record your first meeting to get started!
+              </p>
+            </div>
+          )}
+          <div className="card-footer text-muted small">
+            <AlertCircle size={14} className="me-1" />
+            Meetings are automatically deleted after 12 hours
           </div>
-        ) : (
-          <div className="text-center text-muted py-4">
-            <p className="mb-0">
-              No recent meetings. Upload or record your first meeting to get started!
-            </p>
-          </div>
-        )}
-        <div className="card-footer text-muted small">
-          <AlertCircle size={14} className="me-1" />
-          Meetings are automatically deleted after 12 hours
-        </div>
-      </Card.Body>
-    </Card>
+        </Card.Body>
+      </Card>
 
       <Modal show={!!pendingDeleteUuid} onHide={() => setPendingDeleteUuid(null)}>
         <Modal.Header closeButton>

--- a/frontend/src/components/Upload/RecentJobsList.jsx
+++ b/frontend/src/components/Upload/RecentJobsList.jsx
@@ -113,12 +113,12 @@ export default function RecentJobsList({
           Are you sure you want to delete this meeting? This action cannot be undone.
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="secondary" onClick={() => setPendingDeleteUuid(null)}>
+          <button type="button" className="btn btn-outline-secondary" onClick={() => setPendingDeleteUuid(null)}>
             Cancel
-          </Button>
-          <Button variant="danger" onClick={onConfirmDelete}>
+          </button>
+          <button type="button" className="btn btn-outline-danger" onClick={onConfirmDelete}>
             Delete
-          </Button>
+          </button>
         </Modal.Footer>
       </Modal>
     </>

--- a/frontend/src/hooks/useJobHistory.js
+++ b/frontend/src/hooks/useJobHistory.js
@@ -97,15 +97,7 @@ export default function useJobHistory(
   };
 
   // Delete a job
-  const handleDeleteJob = async (uuid, event) => {
-    event.stopPropagation(); // Prevent triggering the job load
-
-    if (
-      !window.confirm('Are you sure you want to delete this meeting? This action cannot be undone.')
-    ) {
-      return;
-    }
-
+  const handleDeleteJob = async (uuid) => {
     try {
       setError(null);
       await api.deleteJob(uuid);


### PR DESCRIPTION
## Summary

- Remove "Selected: filename" text shown after picking a file in the upload card (redundant noise)
- Rename ambiguous "Unknown" status badge → **"Failed"** with red (`danger`) styling so users know the job didn't complete
- Replace browser-native `window.confirm()` delete dialog with an **SGDS Modal** for a consistent, on-brand confirmation experience

## Test plan
- [ ] Upload a file — confirm "Selected: …" text no longer appears
- [ ] Check Recent Meetings list for a failed job — badge should show "Failed" in red
- [ ] Click the trash icon on a recent meeting — SGDS modal should appear; Cancel closes it, Delete removes the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)