### PR TITLE
chore: make linter workflow manual dispatch only

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -2,14 +2,6 @@ name: Lint Frontend
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'frontend/**'
-  push:
-    branches:
-      - main
-    paths:
-      - 'frontend/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
Closes #188

## Summary
- Removed `pull_request` and `push` triggers from `lint-frontend.yml`
- Workflow now only runs via manual dispatch (`workflow_dispatch`)

## Test plan
- [ ] Verify workflow no longer triggers on push/PR
- [ ] Verify workflow can be triggered manually from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)