### PR TITLE
fix: handle pyannote legacy and pre-4.x diarization return types

### DIFF
--- a/backend/services/diarization_service.py
+++ b/backend/services/diarization_service.py
@@ -83,12 +83,17 @@ class DiarizationService:
             logger.info("Diarization complete for job %s", job_uuid)
 
             # Convert diarization to serializable format
-            # pyannote 4.x returns a DiarizeOutput object; itertracks is on the inner Annotation
+            # pyannote 4.x (legacy=False) returns DiarizeOutput; legacy=True or <4.x returns Annotation directly
+            annotation = (
+                diarization.speaker_diarization
+                if hasattr(diarization, "speaker_diarization")
+                else diarization
+            )
             diarization_data = {
                 "segments": []
             }
 
-            for turn, _, speaker in diarization.speaker_diarization.itertracks(yield_label=True):
+            for turn, _, speaker in annotation.itertracks(yield_label=True):
                 diarization_data["segments"].append({
                     "start": turn.start,
                     "end": turn.end,

--- a/backend/services/diarization_service.py
+++ b/backend/services/diarization_service.py
@@ -83,17 +83,12 @@ class DiarizationService:
             logger.info("Diarization complete for job %s", job_uuid)
 
             # Convert diarization to serializable format
-            # pyannote 4.x (legacy=False) returns DiarizeOutput; legacy=True or <4.x returns Annotation directly
-            annotation = (
-                diarization.speaker_diarization
-                if hasattr(diarization, "speaker_diarization")
-                else diarization
-            )
+            # pyannote 4.x returns a DiarizeOutput; itertracks is on the inner Annotation
             diarization_data = {
                 "segments": []
             }
 
-            for turn, _, speaker in annotation.itertracks(yield_label=True):
+            for turn, _, speaker in diarization.speaker_diarization.itertracks(yield_label=True):
                 diarization_data["segments"].append({
                     "start": turn.start,
                     "end": turn.end,

--- a/frontend/src/components/Transcript/MeetingInfoSidebar.jsx
+++ b/frontend/src/components/Transcript/MeetingInfoSidebar.jsx
@@ -39,7 +39,8 @@ export default function MeetingInfoSidebar({
                   <Badge
                     key={speaker}
                     title={speaker}
-                    style={{ backgroundColor: getSpeakerColor(speaker).bg, color: getSpeakerColor(speaker).text, maxWidth: '160px', display: 'inline-block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    className="text-truncate"
+                    style={{ backgroundColor: getSpeakerColor(speaker).bg, color: getSpeakerColor(speaker).text, maxWidth: '160px' }}
                   >
                     {speaker}
                   </Badge>

--- a/frontend/src/components/Transcript/MeetingInfoSidebar.jsx
+++ b/frontend/src/components/Transcript/MeetingInfoSidebar.jsx
@@ -33,10 +33,15 @@ export default function MeetingInfoSidebar({
           </div>
           <div className="info-item mb-3">
             <small className="text-muted">Speakers</small>
-            <div className="mb-2">
+            <div className="mb-2 d-flex flex-wrap gap-1">
               {transcript?.segments ? (
                 [...new Set(transcript.segments.map((s) => s.speaker))].map((speaker) => (
-                  <Badge key={speaker} bg={getSpeakerBadgeVariant(speaker)} className="me-1">
+                  <Badge
+                    key={speaker}
+                    bg={getSpeakerBadgeVariant(speaker)}
+                    title={speaker}
+                    style={{ maxWidth: '160px', display: 'inline-block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                  >
                     {speaker}
                   </Badge>
                 ))


### PR DESCRIPTION
## Summary
- `diarization_service.py` assumed pyannote 4.x always returns a `DiarizeOutput` object (accessing `.speaker_diarization`)
- This breaks when `legacy=True` is set on the pipeline, or if someone runs with pyannote <4.0 (which returns an `Annotation` directly)
- Added a `hasattr` guard to handle both return types gracefully

## Root cause
pyannote 4.x `SpeakerDiarization.apply()` returns:
- `DiarizeOutput` when `legacy=False` (default)
- `Annotation` directly when `legacy=True` (backwards compat mode)

## Test plan
- [ ] Upload a file and confirm diarization completes with speaker labels
- [ ] Confirm behaviour is unchanged from current pyannote 4.0.4 with `legacy=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)