### PR TITLE
fix: add native RTX 50xx (Blackwell / sm_120) GPU support

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
-## Use official PyTorch image with CUDA 12.6 + PyTorch 2.12.0
-## RTX 50xx (Blackwell) is supported via NVIDIA's forward compatibility layer (driver 570+)
-FROM pytorch/pytorch:2.12.0-cuda12.6-cudnn9-runtime
+## Use PyTorch 2.8.0 + CUDA 12.8 for native RTX 50xx (Blackwell / sm_120) kernel support.
+## CUDA 12.x keeps libcublas.so.12 intact for ctranslate2/faster-whisper.
+FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime
 
 # Prevent Python from writing .pyc files and enable unbuffered logging
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -29,7 +29,7 @@ RUN apt-get update && \
 # Copy dependencies list
 COPY requirements.txt /app/requirements.txt
 
-# Install Python dependencies (torch 2.12.0 + CUDA 13 pulled in by pyannote.audio)
+# Install Python dependencies
 RUN pip install --break-system-packages -r requirements.txt
 
 # Copy application code

--- a/backend/services/diarization_service.py
+++ b/backend/services/diarization_service.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 
 import torch
+import torchaudio
 from pyannote.audio import Pipeline
 
 from config import Settings
@@ -74,10 +75,16 @@ class DiarizationService:
             # Get cached pipeline
             pipeline = self.get_pipeline()
 
-            # Diarize audio - run in executor to avoid blocking event loop
+            # Diarize audio - run in executor to avoid blocking event loop.
+            # Pre-load via torchaudio so pyannote receives a waveform tensor rather
+            # than a file path; this bypasses torchcodec which fails on CUDA 12.8.
             await self.job_repo.update_step_progress(job_uuid, 10)
+            waveform, sample_rate = torchaudio.load(file_path)
             loop = asyncio.get_event_loop()
-            diarization = await loop.run_in_executor(None, pipeline, file_path)
+            diarization = await loop.run_in_executor(
+                None,
+                lambda: pipeline({"waveform": waveform, "sample_rate": sample_rate})
+            )
 
             await self.job_repo.update_step_progress(job_uuid, 90)
             logger.info("Diarization complete for job %s", job_uuid)

--- a/backend/services/diarization_service.py
+++ b/backend/services/diarization_service.py
@@ -76,15 +76,15 @@ class DiarizationService:
             pipeline = self.get_pipeline()
 
             # Diarize audio - run in executor to avoid blocking event loop.
-            # Pre-load via torchaudio so pyannote receives a waveform tensor rather
-            # than a file path; this bypasses torchcodec which fails on CUDA 12.8.
+            # torchaudio.load + pipeline are both blocking; bundle them together
+            # so neither runs on the event loop thread. Passing the waveform dict
+            # bypasses torchcodec, which fails on CUDA 12.8.
             await self.job_repo.update_step_progress(job_uuid, 10)
-            waveform, sample_rate = torchaudio.load(file_path)
             loop = asyncio.get_event_loop()
-            diarization = await loop.run_in_executor(
-                None,
-                lambda: pipeline({"waveform": waveform, "sample_rate": sample_rate})
-            )
+            def _load_and_diarize():
+                waveform, sample_rate = torchaudio.load(file_path)
+                return pipeline({"waveform": waveform, "sample_rate": sample_rate})
+            diarization = await loop.run_in_executor(None, _load_and_diarize)
 
             await self.job_repo.update_step_progress(job_uuid, 90)
             logger.info("Diarization complete for job %s", job_uuid)


### PR DESCRIPTION
Closes #194
Relates to #179

## Summary
- Switch backend base image from `pytorch:2.12.0-cuda12.6` to `pytorch:2.8.0-cuda12.8-cudnn9-runtime` — first PyTorch release with native sm_120 (Blackwell) compiled kernels; the previous image only covered up to sm_90
- Pre-load audio via `torchaudio.load` and pass `{"waveform": ..., "sample_rate": ...}` to the pyannote pipeline instead of a file path, bypassing `torchcodec` which fails under CUDA 12.8
- CUDA 12.x preserves `libcublas.so.12`, so `ctranslate2`/faster-whisper is unaffected

## Test plan
- [ ] Build the Docker image and confirm no dependency errors
- [ ] Run diarization on a machine with an RTX 50xx GPU (sm_120) to confirm the CUDA kernel error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)